### PR TITLE
chore(package.json): add dotenv package to manage environment variables

### DIFF
--- a/starter-kit/package-lock.json
+++ b/starter-kit/package-lock.json
@@ -13,6 +13,7 @@
         "@fiatconnect/fiatconnect-types": "^13.2.2",
         "axios": "^1.6.2",
         "bullmq": "^4.14.4",
+        "dotenv": "^16.3.1",
         "redis": "^4.6.11",
         "winston": "^3.10.0",
         "winston-daily-rotate-file": "^4.7.1"
@@ -4540,6 +4541,17 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -14442,6 +14454,11 @@
           "dev": true
         }
       }
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.601",

--- a/starter-kit/package.json
+++ b/starter-kit/package.json
@@ -24,6 +24,7 @@
     "@fiatconnect/fiatconnect-types": "^13.2.2",
     "axios": "^1.6.2",
     "bullmq": "^4.14.4",
+    "dotenv": "^16.3.1",
     "redis": "^4.6.11",
     "winston": "^3.10.0",
     "winston-daily-rotate-file": "^4.7.1"
@@ -33,7 +34,9 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-typescript": "^7.10.4",
     "@prisma/client": "^4.16.2",
-
+    "@types/jest": "^27.5.2",
+    "@types/morgan": "^1.9.4",
+    "@types/node": "^18.16.16",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.00",
     "babel-jest": "^29.7.0",
@@ -52,13 +55,9 @@
     "prettier": "^2.1.1",
     "pretty-quick": "^3.0.0",
     "prisma": "^4.12.0",
-  
     "ts-jest": "^27.1.5",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.3",
-    "@types/jest": "^27.5.2",
-    "@types/morgan": "^1.9.4",
-    "@types/node": "^18.16.16"
+    "typescript": "^5.1.3"
   },
   "husky": {
     "hooks": {

--- a/starter-kit/src/index.ts
+++ b/starter-kit/src/index.ts
@@ -1,5 +1,5 @@
-import { PrismaClient } from "@prisma/client"
-import { logger } from "./utils/logger"
+require('dotenv').config()
+
 import { createWorker } from "./workers/factory";
 import { optsDefault } from "./utils/queue";
 import { notificationsQueueName, paymentCompleteQueueName, paymentReceivedQueueName, paymentStartedQueueName, paymentsReadyQueueName } from "./workers/types";

--- a/starter-kit/src/utils/queue.ts
+++ b/starter-kit/src/utils/queue.ts
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 import { createHmac } from 'crypto'
 import axios, { AxiosResponse } from 'axios'
 import { IKYCJobData, ITransferEventData } from '../types/webhook'


### PR DESCRIPTION
chore(package.json): update dev dependencies for typescript, jest, morgan, and node
chore(index.ts): add dotenv configuration to load environment variables
chore(queue.ts): add dotenv configuration to load environment variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Integrated environment configuration using `dotenv` for better management of environment variables.

- **Chores**
	- Updated import statements to align with new environment configuration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->